### PR TITLE
Use ADD/MULTIPLY instead of OPERATE

### DIFF
--- a/src/pyopmspe11/templates/co2/spe11a.mako
+++ b/src/pyopmspe11/templates/co2/spe11a.mako
@@ -75,8 +75,8 @@ PERMX PERMZ /
 /
 
 % if dic["kzMult"] > 0:
-OPERATE
-PERMZ 1* 1* 1* 1* 1* 1* 'MULTX' PERMZ ${dic["kzMult"]} /
+MULTIPLY
+PERMZ ${dic["kzMult"]} /
 /
 % endif
 
@@ -98,8 +98,8 @@ ${dic['noCells'][0]*dic['noCells'][1]*dic['noCells'][2]}*${dic["dispersion"]} /
 ----------------------------------------------------------------------------
 EDIT
 ----------------------------------------------------------------------------
-OPERATE
-PORV 1* 1* 1* 1* 1 1 ADDX PORV ${dic["spe11aBC"]} /
+ADD
+PORV ${dic["spe11aBC"]} 4* 1 1 /
 /
 % endif
 ----------------------------------------------------------------------------

--- a/src/pyopmspe11/templates/co2/spe11b.mako
+++ b/src/pyopmspe11/templates/co2/spe11b.mako
@@ -81,8 +81,8 @@ PERMX PERMZ /
 /
 
 % if dic["kzMult"] > 0:
-OPERATE
-PERMZ 1* 1* 1* 1* 1* 1* 'MULTX' PERMZ ${dic["kzMult"]} /
+MULTIPLY
+PERMZ ${dic["kzMult"]} /
 /
 % endif
 

--- a/src/pyopmspe11/templates/co2/spe11c.mako
+++ b/src/pyopmspe11/templates/co2/spe11c.mako
@@ -62,8 +62,8 @@ PERMX PERMZ /
 /
 
 % if dic["kzMult"] > 0:
-OPERATE
-PERMZ 1* 1* 1* 1* 1* 1* 'MULTX' PERMZ ${dic["kzMult"]} /
+MULTIPLY
+PERMZ ${dic["kzMult"]} /
 /
 % endif
 


### PR DESCRIPTION
OPERATE is a complex keyword but the operations needed for SPE11 are fairly simple. This should create functionally identical input files that are a bit easier to parse in codes with limited input file support.
