### PR TITLE
Updates after post in SPEConnect

### DIFF
--- a/src/pyopmspe11/templates/co2/spe11a.mako
+++ b/src/pyopmspe11/templates/co2/spe11a.mako
@@ -22,8 +22,10 @@ CO2STORE
 % if dic['model'] == 'complete':
 % if dic["co2store"] == "gaswater":
 DISGASW
+VAPWAT
 % else:
 DISGAS
+VAPOIL
 % endif
 % if (dic["diffusion"][0] + dic["diffusion"][1]) > 0:
 DIFFUSE
@@ -148,6 +150,10 @@ RPTRST
 RSVD
 0   0.0
 ${dic['dims'][2]} 0.0 /
+
+RVVD
+0   0.0
+${dic['dims'][2]} 0.0 /
 % endif
 
 RTEMPVD
@@ -161,10 +167,17 @@ PERFORMA
 FGIP
 FGIR
 FGIT
+% if dic["flow_version"] != "2023.10":
+RGKDI
+/
+RGKDM
+/
+% else:
 RGCDI
 /
 RGCDM
 /
+% endif
 RGIP
 /
 RWCD

--- a/src/pyopmspe11/templates/co2/spe11b.mako
+++ b/src/pyopmspe11/templates/co2/spe11b.mako
@@ -183,10 +183,17 @@ PERFORMA
 FGIP
 FGIR
 FGIT
+% if dic["flow_version"] != "2023.10":
+RGKDI
+/
+RGKDM
+/
+% else:
 RGCDI
 /
 RGCDM
 /
+% endif
 RGIP
 /
 RWCD

--- a/src/pyopmspe11/templates/co2/spe11c.mako
+++ b/src/pyopmspe11/templates/co2/spe11c.mako
@@ -164,10 +164,17 @@ PERFORMA
 FGIP
 FGIR
 FGIT
+% if dic["flow_version"] != "2023.10":
+RGKDI
+/
+RGKDM
+/
+% else:
 RGCDI
 /
 RGCDM
 /
+% endif
 RGIP
 /
 RWCD

--- a/src/pyopmspe11/visualization/plotting.py
+++ b/src/pyopmspe11/visualization/plotting.py
@@ -374,8 +374,6 @@ def dense_data(dic):
     for kind in dic["kinds"]:
         dic = handle_kind(dic, kind)
         for k, quantity in enumerate(dic["quantities"]):
-            if dic["case"] == "spe11a" and quantity == "xh20":
-                continue
             dic["ptimes"] = dic["times"][: dic["allplots"][k]] + [dic["times"][-1]]
             dic = ini_quantity_plot(dic)
             csv = np.genfromtxt(


### PR DESCRIPTION
- The immobile free-phase is computed at saturations for which the nonwetting relative permeability equals zero.
- In the sparse data, the significant digits for pressure (spe11a) and time (spe11b/c) are increased.

https://connect.spe.org/discussion/feedback-after-participant-workshop#bm19142046-425c-4379-a80e-4095bf33d3f8

In addition, the mass fraction of H20 in vapor for spe11a is included in the simulations, as well as fixing a bug for the computation of the runtimes (the time for LSetup was not added from the .INFOSTEP file).