### PR TITLE
Improvements in the reporting data

### DIFF
--- a/src/pyopmspe11/visualization/plotting.py
+++ b/src/pyopmspe11/visualization/plotting.py
@@ -395,8 +395,8 @@ def dense_data(dic):
                     skip_header=1,
                 )
                 quan = np.array([csv[i][dic["dims"] + k] for i in range(csv.shape[0])])
-                dic["min"].append(quan[quan >= 0].min())
-                dic["max"].append(quan[quan >= 0].max())
+                dic["min"].append(quan[~np.isnan(quan)].min())
+                dic["max"].append(quan[~np.isnan(quan)].max())
                 if quantity == "tco2":
                     dic["sum"].append(quan[quan >= 0].sum())
                 dic["minc"] = min(dic["minc"], dic["min"][-1])
@@ -448,8 +448,6 @@ def dense_data(dic):
                         + f", {dic['case']} ({dic['folders'][0]})"
                     )
                 axis.axis("scaled")
-                axis.set_xlabel("x [m]")
-                axis.set_ylabel("z [m]")
                 divider = make_axes_locatable(axis)
                 vect = np.linspace(
                     dic["minc"],

--- a/tests/configs/input.txt
+++ b/tests/configs/input.txt
@@ -49,4 +49,6 @@ PERM7    1e-5 PORO7 1e-6 DISP7 0 THCONR7 2.00
 
 """Define the injection values ([hours] for spe11a; [years] for spe11b/c)""" 
 """injection time, time step size to write results, maximum solver time step, injected fluid (0 water, 1 co2) (well1), injection rate [kg/s] (well1), temperature [C] (well1), injected fluid (0 water, 1 co2) (well2), ..."""
-25 5 .1 1 0.035 10 1 0 10
+999.9 999.9 10 1     0 10 1 0 10
+   .1    .1 .1 1     0 10 1 0 10
+   25     5 .1 1 0.035 10 1 0 10


### PR DESCRIPTION
The summary TCPU is used to report the runtime. In addition, the "performance time series detailed" now is written uniquely over time (before it was reported as it is done in the .INFOSTEP, where times are duplicated for failed time steps). Also, it seems now that the arat and cvol quantities are correctly computed. 