### PR TITLE
Adding the keyword THCO2MIX to the decks

### DIFF
--- a/src/pyopmspe11/templates/co2/spe11a.mako
+++ b/src/pyopmspe11/templates/co2/spe11a.mako
@@ -125,6 +125,11 @@ DIFFC
 18.01528E-3 44.018E-3 ${dic["diffusion"][1]} ${dic["diffusion"][1]} ${dic["diffusion"][0]} ${dic["diffusion"][0]} /
 % endif
 % endif
+
+% if dic["flow_version"] != "2023.10":
+THCO2MIX
+NONE NONE NONE /
+% endif
 ----------------------------------------------------------------------------
 REGIONS
 ----------------------------------------------------------------------------

--- a/src/pyopmspe11/templates/co2/spe11b.mako
+++ b/src/pyopmspe11/templates/co2/spe11b.mako
@@ -141,6 +141,11 @@ ${dic["temperature"][1]} ${dic["rockExtra"][0]}
 ${dic["temperature"][0]} ${dic["rockExtra"][0]} /
 % endfor
 % endif
+
+% if dic["flow_version"] != "2023.10":
+THCO2MIX
+NONE NONE NONE /
+% endif
 ----------------------------------------------------------------------------
 REGIONS
 ----------------------------------------------------------------------------

--- a/src/pyopmspe11/templates/co2/spe11c.mako
+++ b/src/pyopmspe11/templates/co2/spe11c.mako
@@ -122,6 +122,11 @@ ${dic["temperature"][1]} ${dic["rockExtra"][0]}
 ${dic["temperature"][0]} ${dic["rockExtra"][0]} /
 % endfor
 % endif
+
+% if dic["flow_version"] != "2023.10":
+THCO2MIX
+NONE NONE NONE /
+% endif
 ----------------------------------------------------------------------------
 REGIONS
 ----------------------------------------------------------------------------

--- a/src/pyopmspe11/visualization/plotting.py
+++ b/src/pyopmspe11/visualization/plotting.py
@@ -250,12 +250,20 @@ def sparse_data(dic):
                         color="k",
                         linestyle=dic["linestyle"][-1 + j],
                     )
-                axis.plot(
-                    times,
-                    [csv[i][ncol] for i in range(csv.shape[0])],
-                    color=dic["colors"][nfol],
-                    linestyle=dic["linestyle"][-1 + j],
-                )
+                if label == "MC":
+                    axis.plot(
+                        times,
+                        [csv[i][ncol] for i in range(csv.shape[0])],
+                        color=dic["colors"][nfol],
+                        linestyle=dic["linestyle"][-1 + j + nfol],
+                    )
+                else:
+                    axis.plot(
+                        times,
+                        [csv[i][ncol] for i in range(csv.shape[0])],
+                        color=dic["colors"][nfol],
+                        linestyle=dic["linestyle"][-1 + j],
+                    )
                 ncol += 1
         axis.set_title(plot + f", {dic['case']}")
         axis.set_ylabel(ylabel)


### PR DESCRIPTION
For Flow master, we set the thermal mixing model as described in the benchmark document (https://github.com/OPM/opm-common/pull/4012). In addition, this PR computes the aspect ratio for the cells in spe11c using the diagonal length in the xy direction, as well as improving the mapping from the simulation grid to the reporting grid for the extensive quantities in the spe11c case, and changing the line style for the M_c plot to differentiate overlapping lines when using the compare functionality. 