### PR TITLE
Add tuned NLDD cases

### DIFF
--- a/examples/finner_grids/spe11a1mm_nldd_tuned.txt
+++ b/examples/finner_grids/spe11a1mm_nldd_tuned.txt
@@ -1,0 +1,53 @@
+"""Set the full path to the flow executable and flags"""
+mpirun -np 12 flow --nonlinear-solver=nldd --matrix-add-well-contributions=1 --tolerance-mb=1e-7 --linear-solver=cpr_trueimpes --enable-tuning=false --solver-max-time-step-in-days=0.02 --enable-opm-rst-file=true --output-extra-convergence-info=steps,iterations --newton-min-iterations=1 --threads-per-process=1 --time-step-control-target-newton-iterations=2 --time-step-control-growth-rate=1.15 --time-step-control-decay-rate=0.85 --newton-max-iterations=6 --min-time-step-before-shutting-problematic-wells-in-days=1e-99 --relaxed-max-pv-fraction=0 --min-strict-cnv-iter=8 --tolerance-cnv-relaxed=1e-2 --tolerance-cnv=1e-3 --local-domains-ordering-measure=residual --time-step-control=newtoniterationcount --use-update-stabilization=0 --enable-drift-compensation=0 --max-local-solve-iterations=50 --linear-solver-max-iter=50
+"""Set the model parameters"""
+spe11a master     #Name of the spe case (spe11a, spe11b, or spe11c) and OPM Flow version (master or release)
+complete gaswater #Name of the co2 model (immiscible or complete) and co2store implementation (gaswater or gasoil [oil properties are set to water internally in OPM flow])
+cartesian         #Type of grid (cartesian, tensor, or corner-point)
+2.8 0.01 1.2      #Length, width, and depth [m]
+2800              #If cartesian, number of x cells [-]; otherwise, variable array of x-refinment
+1                 #If cartesian, number of y cells [-]; otherwise, variable array of y-refinment [-] (for spe11c)
+1200               #If cartesian, number of z cells [-]; if tensor, variable array of z-refinment; if corner-point, fix array of z-refinment (18 entries)
+20 20             #Temperature bottom and top rig [C]
+1.2 110000 1      #Pressure on the top [Pa] and multiplier for the permeability in the z direction [-] 
+1e-9 1.6e-5       #Diffusion (in liquid and gas) [m^2/s]
+0 0               #Rock specific heat and density (for spe11b/c)
+0 0 0             #Added pore volume on top boundary (for spe11a [if 0, free flow bc]), pore volume on lateral boundaries, and width of buffer cell [m] (for spe11b/c)
+0 0               #Elevation of the parabola and back boundary [m] (for spe11c)
+
+"""Set the saturation functions"""
+(max(0, (s_w - swi) / (1 - swi))) ** 2                                                        #Wetting rel perm saturation function [-]
+(max(0, (1 - s_w - sni) / (1 - sni))) ** 2                                                    #Non-wetting rel perm saturation function [-]
+penmax * math.erf(pen * ((s_w-swi) / (1.-swi)) ** (-(1.0 / 2)) * math.pi**0.5 / (penmax * 2)) #Capillary pressure saturation function [Pa]
+(np.exp(np.flip(np.linspace(0, 5.0, npoints))) - 1) / (np.exp(5.0) - 1)                       #Points to evaluate the saturation functions (s_w) [-]
+
+"""Properties sat functions"""
+"""swi [-], sni [-], pen [Pa], penmax [Pa], npoints [-]"""
+SWI1 0.32 SNI1 0.1 PEN1 1500 PENMAX1 2500 NPOINTS1 1000
+SWI2 0.14 SNI2 0.1 PEN2  300 PENMAX2 2500 NPOINTS2 1000
+SWI3 0.12 SNI3 0.1 PEN3  100 PENMAX3 2500 NPOINTS3 1000
+SWI4 0.12 SNI4 0.1 PEN4   25 PENMAX4 2500 NPOINTS4 1000
+SWI5 0.12 SNI5 0.1 PEN5   10 PENMAX5 2500 NPOINTS5 1000
+SWI6 0.10 SNI6 0.1 PEN6    1 PENMAX6 2500 NPOINTS6 1000
+SWI7    0 SNI7   0 PEN7    0 PENMAX7 2500 NPOINTS7    2
+
+"""Properties rock"""
+"""K [mD], phi [-], disp [m]"""
+PERM1 44529.9988 PORO1 0.44 DISP1 1e-2
+PERM2 506624.985 PORO2 0.43 DISP2 1e-2
+PERM3 1013249.97 PORO3 0.44 DISP3 1e-2
+PERM4 2026499.95 PORO4 0.45 DISP4 1e-2
+PERM5 4052999.88 PORO5 0.43 DISP5 1e-2
+PERM6 10132499.7 PORO6 0.46 DISP6 1e-2
+PERM7          0 PORO7    0 DISP7    0
+
+"""Wells position"""
+"""radius (0 to use the SOURCE keyword instead of well keywords), x, y, and z position [m] (final positions as well for spe11c)"""
+0 0.9 0.005 0.3 #Well 1
+0 1.7 0.005 0.7 #Well 2
+
+"""Define the injection values ([hours] for spe11a; [years] for spe11b/c)""" 
+"""injection time, time step size to write results, maximum solver time step, injected fluid (0 water, 1 co2) (well1), injection rate [kg/s] (well1), temperature [C] (well1), injected fluid (0 water, 1 co2) (well2), ..."""
+2.5 0.5 .00024 1 1.7e-7 20 1      0 20
+2.5 0.5 .00024 1 1.7e-7 20 1 1.7e-7 20
+115 0.5 .00024 1      0 20 1      0 20

--- a/examples/finner_grids/spe11b_cart_1m_nldd_tuned.txt
+++ b/examples/finner_grids/spe11b_cart_1m_nldd_tuned.txt
@@ -1,0 +1,56 @@
+"""Set the full path to the flow executable and flags"""
+mpirun -np 12 flow --nonlinear-solver=nldd --matrix-add-well-contributions=1 --tolerance-mb=1e-7 --linear-solver=cpr_trueimpes --enable-tuning=false --solver-max-time-step-in-days=3650 --enable-opm-rst-file=true --output-extra-convergence-info=steps,iterations --newton-min-iterations=1 --threads-per-process=1 --time-step-control-target-newton-iterations=3 --time-step-control-growth-rate=1.15 --time-step-control-decay-rate=0.85 --newton-max-iterations=6 --min-time-step-before-shutting-problematic-wells-in-days=1e-99 --relaxed-max-pv-fraction=0 --min-strict-cnv-iter=8 --tolerance-cnv-relaxed=1e-2 --tolerance-cnv=1e-3 --local-domains-ordering-measure=residual --time-step-control=newtoniterationcount --use-update-stabilization=0 --enable-drift-compensation=0
+
+"""Set the model parameters"""
+spe11b master     #Name of the spe case (spe11a, spe11b, or spe11c) and OPM Flow version (master or release)
+complete gaswater #Name of the co2 model (immiscible or complete) and co2store implementation (gaswater or gasoil [oil properties are set to water internally in OPM flow])
+cartesian         #Type of grid (cartesian, tensor, or corner-point)
+8400 1 1200       #Length, width, and depth [m]
+8400              #If cartesian, number of x cells [-]; otherwise, variable array of x-refinment
+1                 #If cartesian, number of y cells [-]; otherwise, variable array of y-refinment [-] (for spe11c)
+1200              #If cartesian, number of z cells [-]; if tensor, variable array of z-refinment; if corner-point, fix array of z-refinment (18 entries)
+70 40             #Temperature bottom and top rig [C]            
+300 3e7 0.1       #Datum [m], pressure at the datum [Pa], and multiplier for the permeability in the z direction [-] 
+1e-9 2e-8         #Diffusion (in liquid and gas) [m^2/s]
+8.5e-1 2500       #Rock specific heat and density (for spe11b/c)
+0 5e4 1           #Added pore volume on top boundary (for spe11a [if 0, free flow bc]), pore volume on lateral boundaries, and width of buffer cell [m] (for spe11b/c)
+0 0               #Elevation of the parabola and back boundary [m] (for spe11c)
+
+"""Set the saturation functions"""
+(max(0, (s_w - swi) / (1 - swi))) ** 1.5                                                        #Wetting rel perm saturation function [-]
+(max(0, (1 - s_w - sni) / (1 - sni))) ** 1.5                                                    #Non-wetting rel perm saturation function [-]
+penmax * math.erf(pen * ((s_w-swi) / (1.-swi)) ** (-(1.0 / 1.5)) * math.pi**0.5 / (penmax * 2)) #Capillary pressure saturation function [Pa]
+(np.exp(np.flip(np.linspace(0, 5.0, npoints))) - 1) / (np.exp(5.0) - 1)                         #Points to evaluate the saturation functions (s_w) [-]
+
+"""Properties sat functions"""
+"""swi [-], sni [-], pen [Pa], penmax [Pa], npoints [-]"""
+SWI1 0.32 SNI1 0.1 PEN1 193531.39 PENMAX1 3e7 NPOINTS1 1000
+SWI2 0.14 SNI2 0.1 PEN2   8654.99 PENMAX2 3e7 NPOINTS2 1000
+SWI3 0.12 SNI3 0.1 PEN3   6120.00 PENMAX3 3e7 NPOINTS3 1000
+SWI4 0.12 SNI4 0.1 PEN4   3870.63 PENMAX4 3e7 NPOINTS4 1000
+SWI5 0.12 SNI5 0.1 PEN5   3060.00 PENMAX5 3e7 NPOINTS5 1000
+SWI6 0.10 SNI6 0.1 PEN6   2560.18 PENMAX6 3e7 NPOINTS6 1000
+SWI7    0 SNI7   0 PEN7         0 PENMAX7 3e7 NPOINTS7    2
+
+"""Properties rock"""
+"""K [mD], phi [-], disp [m], thconr [W m-1 K-1]"""
+PERM1 0.10132 PORO1 0.10 DISP1 10 THCONR1 1.90
+PERM2 101.324 PORO2 0.20 DISP2 10 THCONR2 1.25
+PERM3 202.650 PORO3 0.20 DISP3 10 THCONR3 1.25
+PERM4 506.625 PORO4 0.20 DISP4 10 THCONR4 1.25
+PERM5 1013.25 PORO5 0.25 DISP5 10 THCONR5 0.92
+PERM6 2026.50 PORO6 0.35 DISP6 10 THCONR6 0.26
+PERM7    1e-5 PORO7 1e-6 DISP7  0 THCONR7 2.00
+
+"""Wells radius and position"""
+"""radius (0 to use the SOURCE keyword instead of well keywords), x, y, and z position [m] (final positions as well for spe11c)"""
+0 2700. 0.5 300. #Well 1
+0 5100. 0.5 700. #Well 2
+
+"""Define the injection values ([hours] for spe11a; [years] for spe11b/c)"""
+"""injection time, time step size to write results, maximum solver time step, injected fluid (0 water, 1 co2) (well1), injection rate [kg/s] (well1), temperature [C] (well1), injected fluid (0 water, 1 co2) (well2), ..."""
+999.9 999.9     1 1     0 10 1     0 10
+  0.1   0.1   0.1 1     0 10 1     0 10
+   25     5 0.005 1 0.035 10 1     0 10
+   25     5 0.005 1 0.035 10 1 0.035 10
+  950     5 0.005 1     0 10 1     0 10

--- a/examples/finner_grids/spe11c_cart_168_100_120_nldd_tuned.txt
+++ b/examples/finner_grids/spe11c_cart_168_100_120_nldd_tuned.txt
@@ -1,0 +1,58 @@
+"""Set the full path to the flow executable and flags"""
+mpirun -np 12 flow --nonlinear-solver=nldd --matrix-add-well-contributions=1 --tolerance-mb=1e-7 --linear-solver=cpr_trueimpes --enable-tuning=false --solver-max-time-step-in-days=3650 --enable-opm-rst-file=true --output-extra-convergence-info=steps,iterations --newton-min-iterations=1 --threads-per-process=1 --time-step-control-target-newton-iterations=3 --time-step-control-growth-rate=1.15 --time-step-control-decay-rate=0.85 --newton-max-iterations=6 --min-time-step-before-shutting-problematic-wells-in-days=1e-99 --relaxed-max-pv-fraction=0 --min-strict-cnv-iter=8 --tolerance-cnv-relaxed=1e-2 --tolerance-cnv=1e-3 --local-domains-ordering-measure=residual --time-step-control=newtoniterationcount --use-update-stabilization=0 --enable-drift-compensation=0
+
+"""Set the model parameters"""
+spe11c master     #Name of the spe case (spe11a, spe11b, or spe11c) and OPM Flow version (master or release)
+complete gaswater #Name of the co2 model (immiscible or complete) and co2store implementation (gaswater or gasoil [oil properties are set to water internally in OPM flow])
+cartesian         #Type of grid (cartesian, tensor, or corner-point)
+8400 5000 1200    #Length, width, and depth [m]
+168               #If cartesian, number of x cells [-]; otherwise, variable array of x-refinment
+100               #If cartesian, number of y cells [-]; otherwise, variable array of y-refinment [-] (for spe11c)
+120               #If cartesian, number of z cells [-]; if tensor, variable array of z-refinment; if corner-point, fix array of z-refinment (18 entries)
+70 36.12          #Temperature bottom and top rig [C]            
+300 3e7 0.1       #Datum [m], pressure at the datum [Pa], and multiplier for the permeability in the z direction [-] 
+1e-9 2e-8         #Diffusion (in liquid and gas) [m^2/s]
+8.5e-1 2500       #Rock specific heat and density (for spe11b/c)
+0 5e4 1           #Added pore volume on top boundary (for spe11a [if 0, free flow bc]), pore volume on lateral boundaries, and width of buffer cell [m] (for spe11b/c)
+150 10            #Elevation of the parabola and back [m] (for spe11c)
+
+"""Set the saturation functions"""
+(max(0, (s_w - swi) / (1 - swi))) ** 1.5                                                        #Wetting rel perm saturation function [-]
+(max(0, (1 - s_w - sni) / (1 - sni))) ** 1.5                                                    #Non-wetting rel perm saturation function [-]
+penmax * math.erf(pen * ((s_w-swi) / (1.-swi)) ** (-(1.0 / 1.5)) * math.pi**0.5 / (penmax * 2)) #Capillary pressure saturation function [Pa]
+(np.exp(np.flip(np.linspace(0, 5.0, npoints))) - 1) / (np.exp(5.0) - 1)                         #Points to evaluate the saturation functions (s_w) [-]
+
+"""Properties sat functions"""
+"""swi [-], sni [-], pen [Pa], penmax [Pa], npoints [-]"""
+SWI1 0.32 SNI1 0.1 PEN1 193531.39 PENMAX1 3e7 NPOINTS1 1000
+SWI2 0.14 SNI2 0.1 PEN2   8654.99 PENMAX2 3e7 NPOINTS2 1000
+SWI3 0.12 SNI3 0.1 PEN3   6120.00 PENMAX3 3e7 NPOINTS3 1000
+SWI4 0.12 SNI4 0.1 PEN4   3870.63 PENMAX4 3e7 NPOINTS4 1000
+SWI5 0.12 SNI5 0.1 PEN5   3060.00 PENMAX5 3e7 NPOINTS5 1000
+SWI6 0.10 SNI6 0.1 PEN6   2560.18 PENMAX6 3e7 NPOINTS6 1000
+SWI7    0 SNI7   0 PEN7         0 PENMAX7 3e7 NPOINTS7    2
+
+"""Properties rock"""
+"""K [mD], phi [-], disp [m], thconr [W m-1 K-1]"""
+PERM1 0.10132 PORO1 0.10 DISP1 10 THCONR1 1.90
+PERM2 101.324 PORO2 0.20 DISP2 10 THCONR2 1.25
+PERM3 202.650 PORO3 0.20 DISP3 10 THCONR3 1.25
+PERM4 506.625 PORO4 0.20 DISP4 10 THCONR4 1.25
+PERM5 1013.25 PORO5 0.25 DISP5 10 THCONR5 0.92
+PERM6 2026.50 PORO6 0.35 DISP6 10 THCONR6 0.26
+PERM7    1e-5 PORO7 1e-6 DISP7  0 THCONR7 2.00
+
+"""Wells radius and position"""
+"""radius (0 to use the SOURCE keyword instead of well keywords), x, y, and z position [m] (final positions as well for spe11c)"""
+0 2700. 1000. 300. 2700. 4000. 300. #Well 1
+0 5100. 1000. 700. 5100. 4000. 700. #Well 2
+
+"""Define the injection values ([hours] for spe11a; [years] for spe11b/c)"""
+"""injection time, time step size to write results, maximum solver time step, injected fluid (0 water, 1 co2) (well1), injection rate [kg/s] (well1), temperature [C] (well1), injected fluid (0 water, 1 co2) (well2), ..."""
+999.9 999.9   10 1  0 10 1  0 10
+  0.1   0.1  0.1 1  0 10 1  0 10
+   25     5    1 1 50 10 1  0 10
+   25     5    1 1 50 10 1 50 10
+   50    25    1 1  0 10 1  0 10
+  400    50    1 1  0 10 1  0 10
+  500   100    1 1  0 10 1  0 10


### PR DESCRIPTION
Add tuned cases that uses the NLDD non-linear solver. The most important aspect of the tuning has been to use the stronger non-linear solver to be able to take longer timesteps and control the timesteps better to reflect the stronger but more costly non-linear solver. 

On some of my local tests this has given a significant speedup on the SPE11C case, compared to the default configurations in the repo and my own tuned Newton case. Some more benchmarking and tuning might be needed but this should be a good starting point to test the NLDD solver for SPE11.
![image](https://github.com/OPM/pyopmspe11/assets/56504465/0cc045e6-fa60-47dc-b72e-cc1c718e6f0f)
