### PR TITLE
Using rssat to compute M

### DIFF
--- a/examples/finner_grids/spe11a1mm_nldd_tuned.txt
+++ b/examples/finner_grids/spe11a1mm_nldd_tuned.txt
@@ -1,5 +1,6 @@
 """Set the full path to the flow executable and flags"""
 mpirun -np 12 flow --nonlinear-solver=nldd --matrix-add-well-contributions=1 --tolerance-mb=1e-7 --linear-solver=cpr_trueimpes --enable-tuning=false --solver-max-time-step-in-days=0.02 --enable-opm-rst-file=true --output-extra-convergence-info=steps,iterations --newton-min-iterations=1 --threads-per-process=1 --time-step-control-target-newton-iterations=2 --time-step-control-growth-rate=1.15 --time-step-control-decay-rate=0.85 --newton-max-iterations=6 --min-time-step-before-shutting-problematic-wells-in-days=1e-99 --relaxed-max-pv-fraction=0 --min-strict-cnv-iter=8 --tolerance-cnv-relaxed=1e-2 --tolerance-cnv=1e-3 --local-domains-ordering-measure=residual --time-step-control=newtoniterationcount --use-update-stabilization=0 --enable-drift-compensation=0 --max-local-solve-iterations=50 --linear-solver-max-iter=50
+
 """Set the model parameters"""
 spe11a master     #Name of the spe case (spe11a, spe11b, or spe11c) and OPM Flow version (master or release)
 complete gaswater #Name of the co2 model (immiscible or complete) and co2store implementation (gaswater or gasoil [oil properties are set to water internally in OPM flow])

--- a/src/pyopmspe11/core/pyopmspe11.py
+++ b/src/pyopmspe11/core/pyopmspe11.py
@@ -45,7 +45,7 @@ def pyopmspe11():
             os.system(f"mkdir {dic['exe']}/{dic['fol']}/{fil}")
     os.chdir(f"{dic['exe']}/{dic['fol']}")
 
-    if dic["mode"] in ["all", "deck", "deck_flow", "deck_flow_data"]:
+    if dic["mode"] == "all" or "deck" in dic["mode"]:
         # Initialize the grid
         grid(dic)
         # For corner-point grids, get the cell centers by executing flow
@@ -60,18 +60,17 @@ def pyopmspe11():
         positions(dic)
         # Write used opm related files
         opm_files(dic)
-
-    if dic["mode"] in ["all", "flow", "deck_flow", "flow_data", "deck_flow_data"]:
+    if dic["mode"] == "all" or "flow" in dic["mode"]:
         # Run the simulations
         simulations(dic, dic["fol"].upper(), "flow")
 
-    if dic["mode"] in ["all", "data", "flow_data", "deck_flow_data", "data_plot"]:
+    if dic["mode"] == "all" or "data" in dic["mode"]:
         # Write the data
         if not os.path.exists(f"{dic['exe']}/{dic['fol']}/data"):
             os.system(f"mkdir {dic['exe']}/{dic['fol']}/data")
         data(dic)
 
-    if dic["mode"] in ["all", "plot", "data_plot"]:
+    if dic["mode"] == "all" or "plot" in dic["mode"]:
         # Make some useful plots after the studies
         if not os.path.exists(f"{dic['exe']}/{dic['fol']}/figures"):
             os.system(f"mkdir {dic['exe']}/{dic['fol']}/figures")
@@ -97,8 +96,9 @@ def load_parser():
         help="Run the whole framework ('all'), only create decks ('deck'), "
         "only run flow ('flow'), only write benchmark data ('data'), "
         "only create plots ('plot'), deck and run ('deck_flow'), "
-        "data and plot ('data_plot'), run and data ('flow_data'),  or deck, "
-        "run, and data ('deck_flow_data') ('deck_flow' by default).",
+        "data and plot ('data_plot'), run and data ('flow_data'), deck, "
+        "run, and data ('deck_flow_data'), or flow, data, and plot "
+        "('flow_data_plot') ('deck_flow' by default).",
     )
     parser.add_argument(
         "-c",

--- a/src/pyopmspe11/templates/co2/spe11a.mako
+++ b/src/pyopmspe11/templates/co2/spe11a.mako
@@ -42,7 +42,6 @@ WELLDIMS
 ${len(dic['wellijk'])} ${dic['noCells'][2]} ${len(dic['wellijk'])} ${len(dic['wellijk'])} /
 % endif
 
-UNIFIN
 UNIFOUT
 ----------------------------------------------------------------------------
 GRID
@@ -145,7 +144,7 @@ RPTRST
 % if dic['model'] == 'immiscible': 
 'BASIC=2' FLOWS FLORES DEN/
 % else:
-'BASIC=2' DEN ${'PCGW' if dic["co2store"] == "gaswater" else ''}/
+'BASIC=2' DEN ${'PCGW' if dic["co2store"] == "gaswater" else ''}  ${'RSWSAT' if dic["version"] == "master" and dic["co2store"] == "gaswater" else ''} ${'RSSAT' if dic["version"] == "master" and dic["co2store"] == "gasoil" else ''}/
 % endif
 
 % if dic['model'] == 'complete':
@@ -193,10 +192,10 @@ ${sensor[0]+1} ${sensor[1]+1} ${sensor[2]+1} /
 SCHEDULE
 ----------------------------------------------------------------------------
 RPTRST
-% if dic['model'] == 'immiscible': 
+% if dic['model'] == 'immiscible':
 'BASIC=2' FLOWS FLORES DEN/
 % else:
-'BASIC=2' DEN RESIDUAL ${'PCGW' if dic["co2store"] == "gaswater" else ''}/
+'BASIC=2' DEN RESIDUAL ${'PCGW' if dic["co2store"] == "gaswater" else ''}  ${'RSWSAT' if dic["version"] == "master" and dic["co2store"] == "gaswater" else ''} ${'RSSAT' if dic["version"] == "master" and dic["co2store"] == "gasoil" else ''}/
 % endif
 
 % if sum(dic['radius']) > 0:

--- a/src/pyopmspe11/templates/co2/spe11b.mako
+++ b/src/pyopmspe11/templates/co2/spe11b.mako
@@ -46,7 +46,6 @@ WELLDIMS
 ${len(dic['wellijk'])} ${dic['noCells'][2]} ${len(dic['wellijk'])} ${len(dic['wellijk'])} /
 % endif
 
-UNIFIN
 UNIFOUT
 ----------------------------------------------------------------------------
 GRID
@@ -161,7 +160,7 @@ RPTRST
 % if dic['model'] == 'immiscible': 
 'BASIC=2' FLOWS FLORES DEN/
 % else:
-'BASIC=2' DEN ${'PCGW' if dic["co2store"] == "gaswater" else ''}/
+'BASIC=2' DEN ${'PCGW' if dic["co2store"] == "gaswater" else ''}  ${'RSWSAT' if dic["version"] == "master" and dic["co2store"] == "gaswater" else ''} ${'RSSAT' if dic["version"] == "master" and dic["co2store"] == "gasoil" else ''}/
 % endif
 
 % if dic['model'] == 'complete':
@@ -212,7 +211,7 @@ RPTRST
 % if dic['model'] == 'immiscible': 
 'BASIC=2' FLOWS FLORES DEN/
 % else:
-'BASIC=2' DEN RESIDUAL ${'PCGW' if dic["co2store"] == "gaswater" else ''}/
+'BASIC=2' DEN RESIDUAL ${'PCGW' if dic["co2store"] == "gaswater" else ''}  ${'RSWSAT' if dic["version"] == "master" and dic["co2store"] == "gaswater" else ''} ${'RSSAT' if dic["version"] == "master" and dic["co2store"] == "gasoil" else ''}/
 % endif
 
 % if dic['model'] == 'complete':

--- a/src/pyopmspe11/templates/co2/spe11c.mako
+++ b/src/pyopmspe11/templates/co2/spe11c.mako
@@ -46,7 +46,6 @@ WELLDIMS
 ${len(dic['wellijk'])} ${1+max(dic['wellijkf'][0][1]-dic['wellijk'][0][1], dic['wellijkf'][1][1]-dic['wellijk'][1][1])} ${len(dic['wellijk'])} ${len(dic['wellijk'])} /
 % endif
 
-UNIFIN
 UNIFOUT
 ----------------------------------------------------------------------------
 GRID
@@ -142,7 +141,7 @@ RPTRST
 % if dic['model'] == 'immiscible': 
 'BASIC=2' FLOWS FLORES DEN/
 % else:
-'BASIC=2' DEN ${'PCGW' if dic["co2store"] == "gaswater" else ''}/
+'BASIC=2' DEN ${'PCGW' if dic["co2store"] == "gaswater" else ''} ${'RSWSAT' if dic["version"] == "master" and dic["co2store"] == "gaswater" else ''} ${'RSSAT' if dic["version"] == "master" and dic["co2store"] == "gasoil" else ''}/
 % endif
 
 % if dic['model'] == 'complete':
@@ -193,7 +192,7 @@ RPTRST
 % if dic['model'] == 'immiscible': 
 'BASIC=2' FLOWS FLORES DEN/
 % else:
-'BASIC=2' DEN RESIDUAL ${'PCGW' if dic["co2store"] == "gaswater" else ''}/
+'BASIC=2' DEN RESIDUAL ${'PCGW' if dic["co2store"] == "gaswater" else ''} ${'RSWSAT' if dic["version"] == "master" and dic["co2store"] == "gaswater" else ''} ${'RSSAT' if dic["version"] == "master" and dic["co2store"] == "gasoil" else ''}/
 % endif
 
 % if dic['model'] == 'complete':

--- a/tests/configs/spe11a_data_format.txt
+++ b/tests/configs/spe11a_data_format.txt
@@ -2,7 +2,7 @@
 flow --tolerance-mb=1e-7 --linear-solver=cprw --newton-min-iterations=1 --enable-tuning=true --enable-opm-rst-file=true --output-extra-convergence-info=steps,iterations
 
 """Set the model parameters"""
-spe11a master     #Name of the spe case (spe11a, spe11b, or spe11c) and OPM Flow version (master or release)
+spe11a release    #Name of the spe case (spe11a, spe11b, or spe11c) and OPM Flow version (master or release)
 complete gaswater #Name of the co2 model (immiscible or complete) and co2store implementation (gaswater or gasoil [oil properties are set to water internally in OPM flow])
 cartesian         #Type of grid (cartesian, tensor, or corner-point)
 2.8 0.01 1.2      #Length, width, and depth [m]

--- a/tests/configs/spe11b_data_format.txt
+++ b/tests/configs/spe11b_data_format.txt
@@ -2,7 +2,7 @@
 flow --tolerance-mb=1e-7 --linear-solver=cprw --newton-min-iterations=1 --enable-tuning=true --enable-opm-rst-file=true --output-extra-convergence-info=steps,iterations
 
 """Set the model parameters"""
-spe11b master     #Name of the spe case (spe11a, spe11b, or spe11c) and OPM Flow version (master or release)
+spe11b release    #Name of the spe case (spe11a, spe11b, or spe11c) and OPM Flow version (master or release)
 complete gaswater #Name of the co2 model (immiscible or complete) and co2store implementation (gaswater or gasoil [oil properties are set to water internally in OPM flow])
 cartesian         #Type of grid (cartesian, tensor, or corner-point)
 8400 1 1200       #Length, width, and depth [m]

--- a/tests/configs/spe11c_data_format.txt
+++ b/tests/configs/spe11c_data_format.txt
@@ -2,7 +2,7 @@
 flow --tolerance-mb=1e-7 --linear-solver=cprw --enable-tuning=true --enable-opm-rst-file=true --output-extra-convergence-info=steps,iterations --newton-min-iterations=1
 
 """Set the model parameters"""
-spe11c master     #Name of the spe case (spe11a, spe11b, or spe11c) and OPM Flow version (master or release)
+spe11c release    #Name of the spe case (spe11a, spe11b, or spe11c) and OPM Flow version (master or release)
 complete gaswater #Name of the co2 model (immiscible or complete) and co2store implementation (gaswater or gasoil [oil properties are set to water internally in OPM flow])
 corner-point      #Type of grid (cartesian, tensor, or corner-point)
 8400 5000 1200    #Length, width, and depth [m]


### PR DESCRIPTION
We use RSSAT (RSWSAT for a gas water system) in the computation of convection (Eq. 17 in the [benchmark description](https://onepetro.org/SJ/article/29/05/2507/540636/The-11th-Society-of-Petroleum-Engineers)). To compute this way in a water gas system, one needs to build a version of OPM Flow after [this commit](https://github.com/OPM/opm-simulators/pull/5483). Before this commit the max solubility limit was a scalar computed over all time steps inside box C, while now using RSSAT (RSWSAT) this is computed per cell per time step, resulting in lower values of M. 