### PR TITLE
Adding back and front pv buffer in spe11c

### DIFF
--- a/examples/hello_world/spe11a.txt
+++ b/examples/hello_world/spe11a.txt
@@ -2,7 +2,7 @@
 flow --tolerance-mb=1e-7 --linear-solver=cprw --enable-tuning=true --newton-min-iterations=1 --enable-opm-rst-file=true --output-extra-convergence-info=steps,iterations  --enable-well-operability-check=false --min-time-step-before-shutting-problematic-wells-in-days=1e-99
 
 """Set the model parameters"""
-spe11a master     #Name of the spe case (spe11a, spe11b, or spe11c) and OPM Flow version (master or release)
+spe11a release    #Name of the spe case (spe11a, spe11b, or spe11c) and OPM Flow version (master or release)
 complete gaswater #Name of the co2 model (immiscible or complete) and co2store implementation (gaswater or gasoil [oil properties are set to water internally in OPM flow])
 tensor            #Type of grid (cartesian, tensor, or corner-point)
 2.8 0.01 1.2      #Length, width, and depth [m]

--- a/examples/hello_world/spe11b.txt
+++ b/examples/hello_world/spe11b.txt
@@ -2,7 +2,7 @@
 flow --tolerance-mb=1e-7 --linear-solver=cprw --enable-tuning=true --newton-min-iterations=1 --enable-opm-rst-file=true --output-extra-convergence-info=steps,iterations  --enable-well-operability-check=false --min-time-step-before-shutting-problematic-wells-in-days=1e-99
 
 """Set the model parameters"""
-spe11b master     #Name of the spe case (spe11a, spe11b, or spe11c) and OPM Flow version (master or release)
+spe11b release     #Name of the spe case (spe11a, spe11b, or spe11c) and OPM Flow version (master or release)
 complete gaswater #Name of the co2 model (immiscible or complete) and co2store implementation (gaswater or gasoil [oil properties are set to water internally in OPM flow])
 corner-point      #Type of grid (cartesian, tensor, or corner-point)
 8400 1 1200       #Length, width, and depth [m]

--- a/examples/hello_world/spe11c.txt
+++ b/examples/hello_world/spe11c.txt
@@ -2,7 +2,7 @@
 flow --tolerance-mb=1e-7 --linear-solver=cprw --enable-tuning=true --newton-min-iterations=1 --enable-opm-rst-file=true --output-extra-convergence-info=steps,iterations  --enable-well-operability-check=false --min-time-step-before-shutting-problematic-wells-in-days=1e-99
 
 """Set the model parameters"""
-spe11c master     #Name of the spe case (spe11a, spe11b, or spe11c) and OPM Flow version (master or release)
+spe11c release    #Name of the spe case (spe11a, spe11b, or spe11c) and OPM Flow version (master or release)
 complete gaswater #Name of the co2 model (immiscible or complete) and co2store implementation (gaswater or gasoil [oil properties are set to water internally in OPM flow])
 cartesian         #Type of grid (cartesian, tensor, or corner-point)
 8400 5000 1200    #Length, width, and depth [m]


### PR DESCRIPTION
Thanks to the post in [spe connect](https://connect.spe.org/discussion/reporting-boxes-for-11c#bm0c95d322-50e4-463f-ae6d-040a51d81a18), we now add the buffer pore volume on the back and front boundaries for spe11c (before this PR the extra pore volume was added only to the left and right boundaries), as well as identifying the cells on these boundaries for the reporting of the sparse data via fipnum (10 for cells in the seal face and 11 for the remaining cells on the boundaries).