### PR TITLE
Add case for sub-grid convective mixing

### DIFF
--- a/examples/finner_grids/spe11b_cp_10mish_drsdtcon.txt
+++ b/examples/finner_grids/spe11b_cp_10mish_drsdtcon.txt
@@ -1,0 +1,56 @@
+"""Set the full path to the flow executable and flags"""
+mpirun -np 16 flow  --relaxed-max-pv-fraction=0 --tolerance-mb=1e-7 --linear-solver=cprw --newton-min-iterations=1 --enable-tuning=false --enable-opm-rst-file=true --output-extra-convergence-info=steps,iterations
+
+"""Set the model parameters"""
+spe11b master     #Name of the spe case (spe11a, spe11b, or spe11c) and OPM Flow version (master or release)
+convective gaswater #Name of the co2 model (immiscible or complete) and co2store implementation (gaswater or gasoil [oil properties are set to water internally in OPM flow])
+corner-point      #Type of grid (cartesian, tensor, or corner-point)
+8400 1 1200       #Length, width, and depth [m]
+840               #If cartesian, number of x cells [-]; otherwise, variable array of x-refinment
+1                 #If cartesian, number of y cells [-]; otherwise, variable array of y-refinment [-] (for spe11c)
+9,7,1,5,5,3,7,7,10,7,7,8,6,15,5,24,24,7 #If cartesian, number of z cells [-]; if tensor, variable array of z-refinment; if corner-point, fix array of z-refinment (18 entries)
+70 40             #Temperature bottom and top rig [C]            
+300 3e7 0.1       #Datum [m], pressure at the datum [Pa], and multiplier for the permeability in the z direction [-] 
+1e-9 2e-8         #Diffusion (in liquid and gas) [m^2/s]
+8.5e-1 2500       #Rock specific heat and density (for spe11b/c)
+0 5e4 1           #Added pore volume on top boundary (for spe11a [if 0, free flow bc]), pore volume on lateral boundaries, and width of buffer cell [m] (for spe11b/c)
+0 0               #Elevation of the parabola and back boundary [m] (for spe11c)
+
+"""Set the saturation functions"""
+(max(0, (s_w - swi) / (1 - swi))) ** 1.5                                                        #Wetting rel perm saturation function [-]
+(max(0, (1 - s_w - sni) / (1 - sni))) ** 1.5                                                    #Non-wetting rel perm saturation function [-]
+penmax * math.erf(pen * ((s_w-swi) / (1.-swi)) ** (-(1.0 / 1.5)) * math.pi**0.5 / (penmax * 2)) #Capillary pressure saturation function [Pa]
+(np.exp(np.flip(np.linspace(0, 5.0, npoints))) - 1) / (np.exp(5.0) - 1)                         #Points to evaluate the saturation functions (s_w) [-]
+
+"""Properties sat functions"""
+"""swi [-], sni [-], pen [Pa], penmax [Pa], npoints [-]"""
+SWI1 0.32 SNI1 0.1 PEN1 193531.39 PENMAX1 3e7 NPOINTS1 1000
+SWI2 0.14 SNI2 0.1 PEN2   8654.99 PENMAX2 3e7 NPOINTS2 1000
+SWI3 0.12 SNI3 0.1 PEN3   6120.00 PENMAX3 3e7 NPOINTS3 1000
+SWI4 0.12 SNI4 0.1 PEN4   3870.63 PENMAX4 3e7 NPOINTS4 1000
+SWI5 0.12 SNI5 0.1 PEN5   3060.00 PENMAX5 3e7 NPOINTS5 1000
+SWI6 0.10 SNI6 0.1 PEN6   2560.18 PENMAX6 3e7 NPOINTS6 1000
+SWI7    0 SNI7   0 PEN7         0 PENMAX7 3e7 NPOINTS7    2
+
+"""Properties rock"""
+"""K [mD], phi [-], disp [m], thconr [W m-1 K-1]"""
+PERM1 0.10132 PORO1 0.10 DISP1 10 THCONR1 1.90
+PERM2 101.324 PORO2 0.20 DISP2 10 THCONR2 1.25
+PERM3 202.650 PORO3 0.20 DISP3 10 THCONR3 1.25
+PERM4 506.625 PORO4 0.20 DISP4 10 THCONR4 1.25
+PERM5 1013.25 PORO5 0.25 DISP5 10 THCONR5 0.92
+PERM6 2026.50 PORO6 0.35 DISP6 10 THCONR6 0.26
+PERM7    1e-5 PORO7 1e-6 DISP7  0 THCONR7 2.00
+
+"""Wells radius and position"""
+"""radius (0 to use the SOURCE keyword instead of well keywords), x, y, and z position [m] (final positions as well for spe11c)"""
+0 2700. 0.5 300. #Well 1
+0 5100. 0.5 700. #Well 2
+
+"""Define the injection values ([hours] for spe11a; [years] for spe11b/c)"""
+"""injection time, time step size to write results, maximum solver time step, injected fluid (0 water, 1 co2) (well1), injection rate [kg/s] (well1), temperature [C] (well1), injected fluid (0 water, 1 co2) (well2), ..."""
+999.9 999.9    1 1     0 10 1     0 10
+  0.1   0.1  0.1 1     0 10 1     0 10
+   25     5 0.1 1 0.035 10 1     0 10
+   25     5 0.1 1 0.035 10 1 0.035 10
+  950     5  1 1     0 10 1     0 10

--- a/examples/finner_grids/spe11c_cp_168_100_120ish_drsdtcon.txt
+++ b/examples/finner_grids/spe11c_cp_168_100_120ish_drsdtcon.txt
@@ -1,0 +1,58 @@
+"""Set the full path to the flow executable and flags"""
+mpirun -np 70 flow  --relaxed-max-pv-fraction=0 --zoltan-imbalance-tol=1.05 --tolerance-mb=1e-7 --linear-solver=cprw --enable-tuning=true --enable-opm-rst-file=true --output-extra-convergence-info=steps,iterations --newton-min-iterations=1
+
+"""Set the model parameters"""
+spe11c master     #Name of the spe case (spe11a, spe11b, or spe11c) and OPM Flow version (master or release)
+convective gaswater #Name of the co2 model (immiscible or complete) and co2store implementation (gaswater or gasoil [oil properties are set to water internally in OPM flow])
+corner-point      #Type of grid (cartesian, tensor, or corner-point)
+8400 5000 1200    #Length, width, and depth [m]
+168               #If cartesian, number of x cells [-]; otherwise, variable array of x-refinment
+100               #If cartesian, number of y cells [-]; otherwise, variable array of y-refinment [-] (for spe11c)
+9,7,1,5,5,3,7,7,10,7,7,8,6,15,5,24,24,7  #If cartesian, number of z cells [-]; if tensor, variable array of z-refinment; if corner-point, fix array of z-refinment (18 entries)
+70 36.12          #Temperature bottom and top rig [C]            
+300 3e7 0.1       #Datum [m], pressure at the datum [Pa], and multiplier for the permeability in the z direction [-] 
+1e-9 2e-8         #Diffusion (in liquid and gas) [m^2/s]
+8.5e-1 2500       #Rock specific heat and density (for spe11b/c)
+0 5e4 1           #Added pore volume on top boundary (for spe11a [if 0, free flow bc]), pore volume on lateral boundaries, and width of buffer cell [m] (for spe11b/c)
+150 10            #Elevation of the parabola and back [m] (for spe11c)
+
+"""Set the saturation functions"""
+(max(0, (s_w - swi) / (1 - swi))) ** 1.5                                                        #Wetting rel perm saturation function [-]
+(max(0, (1 - s_w - sni) / (1 - sni))) ** 1.5                                                    #Non-wetting rel perm saturation function [-]
+penmax * math.erf(pen * ((s_w-swi) / (1.-swi)) ** (-(1.0 / 1.5)) * math.pi**0.5 / (penmax * 2)) #Capillary pressure saturation function [Pa]
+(np.exp(np.flip(np.linspace(0, 5.0, npoints))) - 1) / (np.exp(5.0) - 1)                         #Points to evaluate the saturation functions (s_w) [-]
+
+"""Properties sat functions"""
+"""swi [-], sni [-], pen [Pa], penmax [Pa], npoints [-]"""
+SWI1 0.32 SNI1 0.1 PEN1 193531.39 PENMAX1 3e7 NPOINTS1 1000
+SWI2 0.14 SNI2 0.1 PEN2   8654.99 PENMAX2 3e7 NPOINTS2 1000
+SWI3 0.12 SNI3 0.1 PEN3   6120.00 PENMAX3 3e7 NPOINTS3 1000
+SWI4 0.12 SNI4 0.1 PEN4   3870.63 PENMAX4 3e7 NPOINTS4 1000
+SWI5 0.12 SNI5 0.1 PEN5   3060.00 PENMAX5 3e7 NPOINTS5 1000
+SWI6 0.10 SNI6 0.1 PEN6   2560.18 PENMAX6 3e7 NPOINTS6 1000
+SWI7    0 SNI7   0 PEN7         0 PENMAX7 3e7 NPOINTS7    2
+
+"""Properties rock"""
+"""K [mD], phi [-], disp [m], thconr [W m-1 K-1]"""
+PERM1 0.10132 PORO1 0.10 DISP1 10 THCONR1 1.90
+PERM2 101.324 PORO2 0.20 DISP2 10 THCONR2 1.25
+PERM3 202.650 PORO3 0.20 DISP3 10 THCONR3 1.25
+PERM4 506.625 PORO4 0.20 DISP4 10 THCONR4 1.25
+PERM5 1013.25 PORO5 0.25 DISP5 10 THCONR5 0.92
+PERM6 2026.50 PORO6 0.35 DISP6 10 THCONR6 0.26
+PERM7    1e-5 PORO7 1e-6 DISP7  0 THCONR7 2.00
+
+"""Wells radius and position"""
+"""radius (0 to use the SOURCE keyword instead of well keywords), x, y, and z position [m] (final positions as well for spe11c)"""
+0 2700. 1000. 300. 2700. 4000. 300. #Well 1
+0 5100. 1000. 700. 5100. 4000. 700. #Well 2
+
+"""Define the injection values ([hours] for spe11a; [years] for spe11b/c)"""
+"""injection time, time step size to write results, maximum solver time step, injected fluid (0 water, 1 co2) (well1), injection rate [kg/s] (well1), temperature [C] (well1), injected fluid (0 water, 1 co2) (well2), ..."""
+999.9 999.9    1 1  0 10 1  0 10
+  0.1   0.1  0.1 1  0 10 1  0 10
+   25     5 0.1 1 50 10 1  0 10
+   25     5 0.1 1 50 10 1 50 10
+   50    25  1 1  0 10 1  0 10
+  400    50  1 1  0 10 1  0 10
+  500   100  1 1  0 10 1  0 10

--- a/src/pyopmspe11/templates/co2/spe11c.mako
+++ b/src/pyopmspe11/templates/co2/spe11c.mako
@@ -10,7 +10,11 @@ EQLDIMS
 /
 
 TABDIMS
+% if dic['model'] != 'convective':
 ${dic['noSands']} 1* ${dic['tabdims']} /
+% else:
+${dic['noSands']} ${dic['noSands']} ${dic['tabdims']} /
+% endif
 
 % if dic["co2store"] == "gaswater":
 WATER
@@ -19,7 +23,7 @@ OIL
 % endif
 GAS
 CO2STORE
-% if dic['model'] == 'complete':
+% if dic['model'] != 'immiscible':
 % if dic["co2store"] == "gaswater":
 DISGASW
 VAPWAT
@@ -72,12 +76,12 @@ PERMZ ${dic["kzMult"]} /
 INCLUDE
 'PORO.INC' /
 
-% if dic['model'] == 'complete':
+% if dic['model'] != 'immiscible':
 INCLUDE
 'THCONR.INC' /
 % endif
 
-% if dic['model'] == 'complete':
+% if dic['model'] != 'immiscible':
 BCCON 
 1 1 ${dic['noCells'][0]} 1 ${dic['noCells'][1]} 1 1 Z-/
 2 1 ${dic['noCells'][0]} 1 ${dic['noCells'][1]} ${dic['noCells'][2]} ${dic['noCells'][2]} Z/
@@ -99,19 +103,36 @@ PROPS
 INCLUDE
 'TABLES.INC' /
 
-% if dic['model'] == 'complete':
+% if dic['model'] != 'immiscible':
 % if dic["co2store"] == "gaswater":
 % if (dic["diffusion"][0] + dic["diffusion"][1]) > 0:
 DIFFAWAT
+% if dic['model'] != 'convective':
 ${dic["diffusion"][0]} ${dic["diffusion"][0]} /
-
+% else:
+%for i in range(dic['noSands']):
+${dic["diffusion"][0]} ${dic["diffusion"][0]} /
+%endfor
+% endif
 DIFFAGAS
+% if dic['model'] != 'convective':
 ${dic["diffusion"][1]} ${dic["diffusion"][1]} /
+%else:
+% for i in range(dic['noSands']): 
+${dic["diffusion"][1]} ${dic["diffusion"][1]} /
+% endfor
+% endif
 % endif
 % else:
 % if (dic["diffusion"][0] + dic["diffusion"][1]) > 0:
 DIFFC
+% if dic['model'] != 'convective':
 18.01528E-3 44.018E-3 ${dic["diffusion"][1]} ${dic["diffusion"][1]} ${dic["diffusion"][0]} ${dic["diffusion"][0]} /
+% else:
+% for i in range(dic['noSands']): 
+18.01528E-3 44.018E-3 ${dic["diffusion"][1]} ${dic["diffusion"][1]} ${dic["diffusion"][0]} ${dic["diffusion"][0]} /
+% endfor
+% endif
 % endif
 % endif
 
@@ -120,10 +141,12 @@ SPECROCK
 ${dic["temperature"][1]} ${dic["rockExtra"][0]*dic["rockExtra"][1]}
 ${dic["temperature"][0]} ${dic["rockExtra"][0]*dic["rockExtra"][1]} /
 % endfor
-% endif
+
 
 THCO2MIX
 NONE NONE NONE /
+
+% endif
 ----------------------------------------------------------------------------
 REGIONS
 ----------------------------------------------------------------------------
@@ -131,6 +154,13 @@ INCLUDE
 'SATNUM.INC' /
 INCLUDE
 'FIPNUM.INC' /
+
+% if dic['model'] == 'convective':
+COPY
+ SATNUM PVTNUM /
+/
+%endif
+
 ----------------------------------------------------------------------------
 SOLUTION
 ---------------------------------------------------------------------------
@@ -144,7 +174,7 @@ RPTRST
 'BASIC=2' DEN ${'PCGW' if dic["co2store"] == "gaswater" else ''} ${'RSWSAT' if dic["version"] == "master" and dic["co2store"] == "gaswater" else ''} ${'RSSAT' if dic["version"] == "master" and dic["co2store"] == "gasoil" else ''}/
 % endif
 
-% if dic['model'] == 'complete':
+% if dic['model'] != 'immiscible':
 % if dic["co2store"] == "gasoil":
 RSVD
 0   0.0
@@ -195,7 +225,19 @@ RPTRST
 'BASIC=2' DEN RESIDUAL ${'PCGW' if dic["co2store"] == "gaswater" else ''} ${'RSWSAT' if dic["version"] == "master" and dic["co2store"] == "gaswater" else ''} ${'RSSAT' if dic["version"] == "master" and dic["co2store"] == "gasoil" else ''}/
 % endif
 
-% if dic['model'] == 'complete':
+% if dic['model'] == 'convective':
+DRSDTCON
+-1.0 /
+0.04 0.34 3.0e-09 ALL /
+-1.0 /
+-1.0 /
+0.04 0.34 3.0e-09 ALL /
+-1.0 /
+-1.0 /
+/
+%endif
+
+% if dic['model'] != 'immiscible':
 BCPROP
 1 THERMAL /
 2 THERMAL /
@@ -260,7 +302,7 @@ ${dic['wellijk'][i][0]} ${dic['wellijk'][i][1]+k} ${dic['wellijk'][i][2] if i==1
 % endfor
 /
 % endif
-% if dic['model'] == 'complete' and max(dic['radius']) > 0:
+% if dic['model'] != 'immiscible' and max(dic['radius']) > 0:
 WTEMP
 % for i in range(len(dic['wellijk'])):
 % if dic['radius'][i] > 0:


### PR DESCRIPTION
Make it possible to activate DRSDTCON by setting model to "convective"

Add example files for running case B and C
Here default DRSDTCON parameters are used
for facies 2 and 6. For the other facies the sub-grid model is deactivated by setting the first parameter to -1