### PR TITLE
Specify figure filename for easier comparison

### DIFF
--- a/docs/text/examples.rst
+++ b/docs/text/examples.rst
@@ -13,8 +13,9 @@ with low grid resolution and shorter injetion times (for initial testing of the 
 
     pyopmspe11 -i spe11b.txt -o spe11b -m all -g all -t 5 -r 50,1,15 -w 1
 
-The following is one of the figures generated related to the CO2 mass in the domain over time (i.e., the simulations results from
-the corner-point grid mapped to the equidistance reporting grid of 50 x 15 as defined by the -r flag):
+The following is the figure `spe11b_tco2_2Dmaps`, which shows the CO2 mass in the domain over time (i.e., the simulations results from
+the corner-point grid mapped to the equidistance reporting grid of 50 x 15 as defined by the -r flag). You can
+compare your example results to this figure to evaluate if your example ran correctly:
 
 .. figure:: figs/spe11b_tco2_2Dmaps.png
 


### PR DESCRIPTION
When running the hello world example it would be nice to be able to easily compare the figure in the documentation to the one generated locally, but at the moment the text does not specify which figure is shown in the documentation (I had to look through the 17 figures generated to find the one that looked similar ;-)). This change mentions the filename and the possibility to compare the generated file to the one in the documentation. Let me know if you prefer a different wording.

Also my editor added a newline at the end of the file. This seems standard in many editors, but if you prefer your files without I can remove it again.

Related to https://github.com/openjournals/joss-reviews/issues/7357