### PR TITLE
Option to hide Python warnings

### DIFF
--- a/src/pyopmspe11/core/pyopmspe11.py
+++ b/src/pyopmspe11/core/pyopmspe11.py
@@ -4,6 +4,7 @@
 """Main script for pyopmspe11"""
 import os
 import argparse
+import warnings
 from pyopmspe11.utils.inputvalues import process_input, check_deck, handle_tuning
 from pyopmspe11.utils.runs import simulations, plotting, data
 from pyopmspe11.visualization.plotting import plot_results
@@ -29,6 +30,9 @@ def pyopmspe11():
     dic["dt_data"] = float(
         cmdargs["write"].strip()
     )  # Temporal resolution to write the sparse and performance data
+    dic["showpywarn"] = int(cmdargs["showpywarn"])  # Show or hidde python warnings
+    if dic["showpywarn"] != 1:
+        warnings.warn = lambda *args, **kwargs: None
     # If the compare plots are generated, then we exit right afterwards
     if dic["compare"]:
         plot_results(dic)
@@ -153,6 +157,12 @@ def load_parser():
         default="0.1",
         help="Time interval for the sparse and performance data (spe11a [h]; spe11b/c [y]) "
         "('0.1' by default).",
+    )
+    parser.add_argument(
+        "-s",
+        "--showpywarn",
+        default=0,
+        help="Set to 1 to show Python warnings ('0' by default).",
     )
     return vars(parser.parse_known_args()[0])
 

--- a/src/pyopmspe11/utils/runs.py
+++ b/src/pyopmspe11/utils/runs.py
@@ -52,6 +52,7 @@ def plotting(dic):
         "-d " + f"{dic['spe11']}",
         "-g " + f"{dic['generate']}",
         "-r " + f"{dic['resolution']}",
+        "-s " + f"{dic['showpywarn']}",
     ]
     print(" ".join(plot_exe))
     prosc = subprocess.run(plot_exe, check=True)
@@ -81,6 +82,7 @@ def data(dic):
         "-t " + f"{dic['time_data']}",
         "-w " + f"{dic['dt_data']}",
         "-u " + f"{dic['use']}",
+        "-s " + f"{dic['showpywarn']}",
     ]
     print(" ".join(data_exe))
     prosc = subprocess.run(data_exe, check=True)

--- a/src/pyopmspe11/visualization/data.py
+++ b/src/pyopmspe11/visualization/data.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2023 NORCE
 # SPDX-License-Identifier: MIT
-# pylint: disable=C0302, R0912, R0914
+# pylint: disable=C0302, R0912, R0914, R0801
 
 """"
 Script to write the benchmark data
@@ -8,6 +8,7 @@ Script to write the benchmark data
 
 import os
 import argparse
+import warnings
 import csv
 from io import StringIO
 from shapely.geometry import Polygon
@@ -86,7 +87,15 @@ def main():
         default="resdata",
         help="Using the 'resdata' or python package (resdata by default).",
     )
+    parser.add_argument(
+        "-s",
+        "--showpywarn",
+        default=0,
+        help="Set to 1 to show Python warnings ('0' by default).",
+    )
     cmdargs = vars(parser.parse_known_args()[0])
+    if int(cmdargs["showpywarn"]) != 1:  # Show or hidde python warnings
+        warnings.warn = lambda *args, **kwargs: None
     dig = {"path": cmdargs["path"].strip()}
     dig["case"] = cmdargs["deck"].strip()
     dig["mode"] = cmdargs["generate"].strip()

--- a/src/pyopmspe11/visualization/plotting.py
+++ b/src/pyopmspe11/visualization/plotting.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2023 NORCE
 # SPDX-License-Identifier: MIT
-# pylint: disable=R0912
+# pylint: disable=R0912, R0801
 
 """"
 Script to plot the results
@@ -8,6 +8,7 @@ Script to plot the results
 
 import argparse
 import os
+import warnings
 import math as mt
 import numpy as np
 import matplotlib
@@ -62,7 +63,15 @@ def main():
         "'dense_performance', 'dense_sparse', 'performance_sparse', "
         "'dense_performance-spatial', 'dense_performance_sparse', or 'all'",
     )
+    parser.add_argument(
+        "-s",
+        "--showpywarn",
+        default=0,
+        help="Set to 1 to show Python warnings ('0' by default).",
+    )
     cmdargs = vars(parser.parse_known_args()[0])
+    if int(cmdargs["showpywarn"]) != 1:  # Show or hidde python warnings
+        warnings.warn = lambda *args, **kwargs: None
     dic = {"folders": [cmdargs["folder"].strip()]}
     dic["case"] = cmdargs["deck"].strip()
     dic["generate"] = cmdargs["generate"].strip()


### PR DESCRIPTION
Addressing the issue in https://github.com/OPM/pyopmspe11/issues/80 (thanks @gassmoeller for pointing this).
If the flag -s is set to 1 (0 by default), Python warnings are written. In the current verison, these warnings come from the resdata dependency. 