### PR TITLE
Make optional to use LaTeX

### DIFF
--- a/src/pyopmspe11/core/pyopmspe11.py
+++ b/src/pyopmspe11/core/pyopmspe11.py
@@ -31,6 +31,7 @@ def pyopmspe11():
         cmdargs["write"].strip()
     )  # Temporal resolution to write the sparse and performance data
     dic["showpywarn"] = int(cmdargs["showpywarn"])  # Show or hidde python warnings
+    dic["latex"] = int(cmdargs["latex"])  # LaTeX formatting
     if dic["showpywarn"] != 1:
         warnings.warn = lambda *args, **kwargs: None
     # If the compare plots are generated, then we exit right afterwards
@@ -163,6 +164,12 @@ def load_parser():
         "--showpywarn",
         default=0,
         help="Set to 1 to show Python warnings ('0' by default).",
+    )
+    parser.add_argument(
+        "-l",
+        "--latex",
+        default=1,
+        help="Set to 0 to not use LaTeX formatting ('1' by default).",
     )
     return vars(parser.parse_known_args()[0])
 

--- a/src/pyopmspe11/utils/runs.py
+++ b/src/pyopmspe11/utils/runs.py
@@ -53,6 +53,7 @@ def plotting(dic):
         "-g " + f"{dic['generate']}",
         "-r " + f"{dic['resolution']}",
         "-s " + f"{dic['showpywarn']}",
+        "-l " + f"{dic['latex']}",
     ]
     print(" ".join(plot_exe))
     prosc = subprocess.run(plot_exe, check=True)

--- a/src/pyopmspe11/visualization/plotting.py
+++ b/src/pyopmspe11/visualization/plotting.py
@@ -17,19 +17,6 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 font = {"family": "normal", "weight": "normal", "size": 20}
 matplotlib.rc("font", **font)
-plt.rcParams.update(
-    {
-        "text.usetex": True,
-        "font.family": "monospace",
-        "legend.columnspacing": 0.9,
-        "legend.handlelength": 3.5,
-        "legend.fontsize": 15,
-        "lines.linewidth": 4,
-        "axes.titlesize": 20,
-        "axes.grid": True,
-        "figure.figsize": (10, 5),
-    }
-)
 
 SECONDS_IN_YEAR = 31536000.0
 
@@ -69,6 +56,12 @@ def main():
         default=0,
         help="Set to 1 to show Python warnings ('0' by default).",
     )
+    parser.add_argument(
+        "-l",
+        "--latex",
+        default=1,
+        help="Set to 0 to not use LaTeX formatting ('1' by default).",
+    )
     cmdargs = vars(parser.parse_known_args()[0])
     if int(cmdargs["showpywarn"]) != 1:  # Show or hidde python warnings
         warnings.warn = lambda *args, **kwargs: None
@@ -76,6 +69,7 @@ def main():
     dic["case"] = cmdargs["deck"].strip()
     dic["generate"] = cmdargs["generate"].strip()
     dic["compare"] = cmdargs["compare"]  # No empty, then the create compare folder
+    dic["latex"] = int(cmdargs["latex"])  # LaTeX formatting
     dic["exe"] = os.getcwd()  # Path to the folder of the configuration file
     plot_results(dic)
 
@@ -91,6 +85,19 @@ def plot_results(dic):
         None
 
     """
+    plt.rcParams.update(
+        {
+            "text.usetex": dic["latex"] not in [0],
+            "font.family": "monospace",
+            "legend.columnspacing": 0.9,
+            "legend.handlelength": 3.5,
+            "legend.fontsize": 15,
+            "lines.linewidth": 4,
+            "axes.titlesize": 20,
+            "axes.grid": True,
+            "figure.figsize": (10, 5),
+        }
+    )
     dic["colors"] = [
         "#1f77b4",
         "#ff7f0e",


### PR DESCRIPTION
Addressing the issue in https://github.com/OPM/pyopmspe11/issues/88 (thanks @MatthewFlamm for pointing this).

If the flag -l is set to 0 (1 by default), then the LaTeX dependency is not required.