### PR TITLE
Make possible to run tests independently

### DIFF
--- a/tests/test_0_spe11a.py
+++ b/tests/test_0_spe11a.py
@@ -4,13 +4,15 @@
 """Test the spe11a case"""
 
 import os
+import pathlib
 import subprocess
+
+dirname: pathlib.Path = pathlib.Path(__file__).parent
 
 
 def test_spe11a():
     """See configs/spe11a_data_format.txt"""
-    cwd = os.getcwd()
-    os.chdir(f"{cwd}/tests/configs")
+    os.chdir(f"{dirname}/configs")
     subprocess.run(
         [
             "pyopmspe11",
@@ -33,5 +35,4 @@ def test_spe11a():
         ],
         check=True,
     )
-    assert os.path.exists(f"{cwd}/tests/configs/spe11a/data/spe11a_time_series.csv")
-    os.chdir(cwd)
+    assert os.path.exists(f"{dirname}/configs/spe11a/data/spe11a_time_series.csv")

--- a/tests/test_1_spe11b.py
+++ b/tests/test_1_spe11b.py
@@ -4,13 +4,14 @@
 """Test the spe11b case"""
 
 import os
+import pathlib
 from pyopmspe11.core.pyopmspe11 import main
+
+dirname: pathlib.Path = pathlib.Path(__file__).parent
 
 
 def test_spe11b():
     """See configs/input.txt"""
-    cwd = os.getcwd()
-    os.chdir(f"{os.getcwd()}/tests/configs")
+    os.chdir(f"{dirname}/configs")
     main()
-    os.chdir(cwd)
-    assert os.path.exists(f"{cwd}/tests/configs/output/flow/OUTPUT.UNRST")
+    assert os.path.exists(f"{dirname}/configs/output/flow/OUTPUT.UNRST")

--- a/tests/test_2_spe11c.py
+++ b/tests/test_2_spe11c.py
@@ -4,20 +4,22 @@
 """Test the spe11c case"""
 
 import os
+import pathlib
 import subprocess
+
+dirname: pathlib.Path = pathlib.Path(__file__).parent
 
 
 def test_spe11c():
     """See configs/spe11c.txt"""
-    cwd = os.getcwd()
-    os.chdir(f"{os.getcwd()}/tests/configs")
+    os.chdir(f"{dirname}/configs")
     subprocess.run(
         [
             "pyopmspe11",
-            "-i",
-            "spe11c.txt",
             "-o",
             "spe11c",
+            "-i",
+            "spe11c.txt",
             "-m",
             "all",
             "-g",
@@ -29,5 +31,4 @@ def test_spe11c():
         ],
         check=True,
     )
-    assert os.path.exists(f"{cwd}/tests/configs/spe11c/figures/spe11c_temp_2Dmaps.png")
-    os.chdir(cwd)
+    assert os.path.exists(f"{dirname}/configs/spe11c/figures/spe11c_temp_2Dmaps.png")

--- a/tests/test_3_data.py
+++ b/tests/test_3_data.py
@@ -4,14 +4,17 @@
 """Test the scrip to write the data as required in the benchmark"""
 
 import os
+import pathlib
 from pyopmspe11.visualization.data import main
+
+dirname: pathlib.Path = pathlib.Path(__file__).parent
 
 
 def test_data():
     """See visualization/data.py"""
-    cwd = os.getcwd()
-    os.mkdir(f"{cwd}/tests/configs/output/data")
-    os.chdir(f"{cwd}/tests/configs")
+    message = "Please run first test_1_spe11b"
+    assert os.path.exists(f"{dirname}/configs/output"), message
+    os.mkdir(f"{dirname}/configs/output/data")
+    os.chdir(f"{dirname}/configs")
     main()
-    assert os.path.exists(f"{cwd}/tests/configs/output/data/spe11b_time_series.csv")
-    os.chdir(cwd)
+    assert os.path.exists(f"{dirname}/configs/output/data/spe11b_time_series.csv")

--- a/tests/test_4_plot.py
+++ b/tests/test_4_plot.py
@@ -4,14 +4,19 @@
 """Test the scrip to plot the data"""
 
 import os
+import pathlib
 from pyopmspe11.visualization.plotting import main
+
+dirname: pathlib.Path = pathlib.Path(__file__).parent
 
 
 def test_plot():
     """See visualization/plotting.py"""
-    cwd = os.getcwd()
-    os.chdir(f"{cwd}/tests/configs")
-    os.mkdir(f"{cwd}/tests/configs/output/figures")
+    message = "Please run first test_1_spe11b"
+    assert os.path.exists(f"{dirname}/configs/output"), message
+    message = "Please run first test_3_data"
+    assert os.path.exists(f"{dirname}/configs/output/data"), message
+    os.chdir(f"{dirname}/configs")
+    os.mkdir(f"{dirname}/configs/output/figures")
     main()
-    assert os.path.exists(f"{cwd}/tests/configs/output/figures/spe11b_sparse_data.png")
-    os.chdir(cwd)
+    assert os.path.exists(f"{dirname}/configs/output/figures/spe11b_sparse_data.png")

--- a/tests/test_5_compare.py
+++ b/tests/test_5_compare.py
@@ -4,27 +4,30 @@
 """Test the scrip to compare the data for different runs"""
 
 import os
+import pathlib
+
+dirname: pathlib.Path = pathlib.Path(__file__).parent
 
 
 def test_comparison():
     """See visualization/plot.py"""
-    cwd = os.getcwd()
-    os.system(f"mkdir {cwd}/tests/configs/test_compare")
-    os.system(f"mkdir {cwd}/tests/configs/test_compare/spe11c_ens1")
-    os.system(f"mkdir {cwd}/tests/configs/test_compare/spe11c_ens2")
+    message = "Please run first test_2_spe11c"
+    assert os.path.exists(f"{dirname}/configs/spe11c"), message
+    os.system(f"mkdir {dirname}/configs/test_compare")
+    os.system(f"mkdir {dirname}/configs/test_compare/spe11c_ens1")
+    os.system(f"mkdir {dirname}/configs/test_compare/spe11c_ens2")
     os.system(
-        f"cp -R {cwd}/tests/configs/spe11c/. {cwd}/tests/configs/test_compare/spe11c_ens1"
+        f"cp -R {dirname}/configs/spe11c/. {dirname}/configs/test_compare/spe11c_ens1"
     )
     os.system(
-        f"cp -R {cwd}/tests/configs/spe11c/. {cwd}/tests/configs/test_compare/spe11c_ens2"
+        f"cp -R {dirname}/configs/spe11c/. {dirname}/configs/test_compare/spe11c_ens2"
     )
-    os.chdir(f"{cwd}/tests/configs/test_compare")
+    os.chdir(f"{dirname}/configs/test_compare")
     os.system("pyopmspe11 -c spe11c -m performance")
-    os.chdir(f"{cwd}/tests/configs")
+    os.chdir(f"{dirname}/configs")
     assert os.path.exists(
-        f"{cwd}/tests/configs/test_compare/compare/spe11c_performance_detailed.png"
+        f"{dirname}/configs/test_compare/compare/spe11c_performance_detailed.png"
     )
     assert os.path.exists(
-        f"{cwd}/tests/configs/test_compare/compare/spe11c_performance.png"
+        f"{dirname}/configs/test_compare/compare/spe11c_performance.png"
     )
-    os.chdir(cwd)

--- a/tests/test_6_data_format.py
+++ b/tests/test_6_data_format.py
@@ -4,16 +4,21 @@
 """Test the format of the generated data for the three cases"""
 
 import os
+import pathlib
 import subprocess
 from subprocess import PIPE, Popen
+
+dirname: pathlib.Path = pathlib.Path(__file__).parent
 
 
 def test_format():
     """See https://github.com/Simulation-Benchmarks/11thSPE-CSP/blob/
     main/evaluation/check_format.py"""
-    cwd = os.getcwd()
-    os.chdir(f"{cwd}/tests/configs")
-    os.system("rm -rf spe11c")
+    message = "Please run first test_0_spe11a"
+    assert os.path.exists(f"{dirname}/configs/spe11a"), message
+    os.chdir(f"{dirname}/configs")
+    if os.path.exists(f"{dirname}/configs/spe11c"):
+        os.system(f"rm -rf {dirname}/configs/spe11c")
     subprocess.run(
         [
             "pyopmspe11",
@@ -84,4 +89,3 @@ def test_format():
     ) as process:
         check = str(process.communicate()[0])[4:-3]
     assert check.count("Successfully") == 2
-    os.chdir(cwd)


### PR DESCRIPTION
Addressing the independent issue inside https://github.com/OPM/pyopmspe11/issues/82 (thanks @gassmoeller for pointing this).

Now it is possible to run the tests independently. e.g., 
`pytest --cov=pyopmspe11 --cov-report term-missing tests/test_1_spe11b.py`

In addition, if running all tests and any of them fail, now with this PR the following tests will be executed independently of the path where the test failed, this by using  `dirname: pathlib.Path = pathlib.Path(__file__).parent`. 

For the tests which depend on any other test to be run and successful first, this is printed now.