### PR TITLE
Improving performance and resdata as requirement

### DIFF
--- a/src/pyopmspe11/utils/mapproperties.py
+++ b/src/pyopmspe11/utils/mapproperties.py
@@ -10,17 +10,14 @@ import csv
 import numpy as np
 import pandas as pd
 from shapely.geometry import Polygon
+from resdata.resfile import ResdataFile
+from resdata.grid import Grid
 
 try:
     from opm.io.ecl import EGrid as OpmGrid
     from opm.io.ecl import EclFile as OpmFile
 except ImportError:
-    print("The opm Python package was not found, using resdata")
-try:
-    from resdata.resfile import ResdataFile
-    from resdata.grid import Grid
-except ImportError:
-    print("The resdata Python package was not found, using opm")
+    pass
 
 
 def grid(dic):
@@ -461,11 +458,13 @@ def get_cell_info(dic, i):
     else:
         dic["xyz"] = dic["gridf"].get_xyz(global_index=i)
         dic["ijk"] = dic["gridf"].get_ijk(global_index=i)
-        vxyz = dic["gridf"].export_corners(dic["gridf"].export_index())[i]
+        if "vxyz" not in dic:
+            dic["vxyz"] = dic["gridf"].export_corners(dic["gridf"].export_index())
         dic["corns"] = (
-            f"{vxyz[0]}, {dic['dims'][2] -vxyz[2]}, {vxyz[3]}, "
-            + f"{dic['dims'][2] -vxyz[5]}, {vxyz[15]}, {dic['dims'][2] -vxyz[17]}, "
-            + f"{vxyz[12]}, {dic['dims'][2] - vxyz[14]}"
+            f"{dic['vxyz'][i][0]}, {dic['dims'][2] - dic['vxyz'][i][2]}, {dic['vxyz'][i][3]}, "
+            + f"{dic['dims'][2] - dic['vxyz'][i][5]}, {dic['vxyz'][i][15]}, "
+            + f"{dic['dims'][2] - dic['vxyz'][i][17]}, "
+            + f"{dic['vxyz'][i][12]}, {dic['dims'][2] - dic['vxyz'][i][14]}"
         )
 
 

--- a/src/pyopmspe11/visualization/data.py
+++ b/src/pyopmspe11/visualization/data.py
@@ -16,6 +16,9 @@ from rtree import index
 import numpy as np
 import pandas as pd
 from scipy.interpolate import interp1d
+from resdata.grid import Grid
+from resdata.resfile import ResdataFile
+from resdata.summary import Summary
 
 try:
     from opm.io.ecl import EclFile as OpmFile
@@ -23,13 +26,7 @@ try:
     from opm.io.ecl import ERst as OpmRestart
     from opm.io.ecl import ESmry as OpmSummary
 except ImportError:
-    print("The Python package opm was not found, using resdata")
-try:
-    from resdata.grid import Grid
-    from resdata.resfile import ResdataFile
-    from resdata.summary import Summary
-except ImportError:
-    print("The resdata Python package was not found, using opm")
+    pass
 
 GAS_DEN_REF = 1.86843
 WAT_DEN_REF = 998.108


### PR DESCRIPTION
With this PR, if a corner-point grid is to be generated using resdata, then the corners are only read once, which significantly reduces the execution time. 

Also resdata is set as a requirement now, then for macOS users it is a requirement to use a Python version higher or equal to 3.10 and less than 3.13 (this upper limit also applies for Linux, since there are no packaged version for resdata, thanks to @gassmoeller and @MatthewFlamm for pointing this in https://github.com/OPM/pyopmspe11/issues/79). This will be mention in the documentation in the following PR. 