### PR TITLE
Explicit write the B box quantities in the csv header

### DIFF
--- a/src/pyopmspe11/visualization/data.py
+++ b/src/pyopmspe11/visualization/data.py
@@ -816,7 +816,7 @@ def write_sparse_data(dig, dil):
         dil[f"{name}"] = interp(dil["times_data"])
     text = [
         "# t [s], p1 [Pa], p2 [Pa], mobA [kg], immA [kg], dissA [kg], sealA [kg], "
-        + "<same for B>, MC [m^2], sealTot [kg]"
+        + "mobB [kg], immB [kg], dissB [kg], sealB [kg], MC [m^2], sealTot [kg]"
     ]
     if dig["case"] == "spe11a":
         for j, time in enumerate(dil["times_data"]):


### PR DESCRIPTION
In the [Benchmark description (Data reporting/Sparse data)](https://onepetro.org/SJ/article/29/05/2507/540636/The-11th-Society-of-Petroleum-Engineers) it is stated to used `< same for B>` in the column header. This PR writes those entries explicitly `mobB [kg], immB [kg], dissB [kg], sealB [kg]`, allowing to get the right column label for each of the entries.